### PR TITLE
Fix the reset to CGAffineTransformIdentity not being animated

### DIFF
--- a/UITextField-Shake/UITextField+Shake.m
+++ b/UITextField-Shake/UITextField+Shake.m
@@ -31,7 +31,9 @@
 		self.transform = (shakeDirection == ShakeDirectionHorizontal) ? CGAffineTransformMakeTranslation(delta * direction, 0) : CGAffineTransformMakeTranslation(0, delta * direction);
 	} completion:^(BOOL finished) {
 		if(current >= times) {
-			self.transform = CGAffineTransformIdentity;
+			[UIView animateWithDuration:interval animations:^{
+				self.transform = CGAffineTransformIdentity;
+			}];
 			return;
 		}
 		[self _shake:(times - 1)


### PR DESCRIPTION
When reseting the text field to its original position with `CGAffineTransformIdentity`, the change is not animated, which makes the text field "jump" at the end of the animation.

Before fix: https://dl.dropboxusercontent.com/u/18386288/UIView%2BShake_before.mov
After fix: https://dl.dropboxusercontent.com/u/18386288/UIView%2BShake_after.mov

(sorry, .mov videos, could not find a satisfying gif converter...)

Also, please note that the first and last animations are executed with the same duration as all the others shakes, but the distance travelled by the view is 2x smaller, making these appear "slower".

Issue mirrored for UIView+Shake here: https://github.com/andreamazz/UIView-Shake/pull/1
