### PR TITLE
Update UITextField+Shake.podspec for ios6

### DIFF
--- a/UITextField+Shake.podspec
+++ b/UITextField+Shake.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.license      = { :type => 'MIT', :file => 'LICENSE' }
   s.author       = { "Andrea Mazzini" => "andrea.mazzini@gmail.com" }
   s.source       = { :git => "https://github.com/andreamazz/UITextField-Shake.git", :tag => "0.3" }
-  s.platform     = :ios, '7.0'
+  s.platform     = :ios, '6.0'
   s.source_files = 'UITextField-Shake', '*.{h,m}'
   s.requires_arc = true
 end


### PR DESCRIPTION
This category already supports ios6 compatibility. Changed podspec to all podfiles that specify ios6+
