### PR TITLE
Shake correct number of times, instead of 1/2 as much

### DIFF
--- a/Source/UITextField+Shake.m
+++ b/Source/UITextField+Shake.m
@@ -11,7 +11,7 @@
 @implementation UITextField (Shake)
 
 - (void)shake {
-    [self shake:10 withDelta:5 completion:nil];
+    [self shake:5 withDelta:5 completion:nil];
 }
 
 - (void)shake:(int)times withDelta:(CGFloat)delta {
@@ -52,7 +52,7 @@
             }];
             return;
         }
-        [self _shake:(times - 1)
+        [self _shake:times
            direction:direction * -1
         currentTimes:current + 1
            withDelta:delta


### PR DESCRIPTION
This could be intended behavior, but by decrementing "times" and incrementing "currentTimes" with each function call, the UITextField will only complete 1/2 as many full shakes as desired.

By "shake", did you mean "one direction" or "a full transform in both directions"?

If this change isn't wanted, perhaps adding some documentation about what constitutes a shake would be nice?

Great class extension, by the way!